### PR TITLE
only ignore existing toc if in write mode

### DIFF
--- a/markdowntoc/markdowntoc.py
+++ b/markdowntoc/markdowntoc.py
@@ -207,7 +207,7 @@ def create_table_of_contents_bear():
         # creation_date = row['ZCREATIONDATE']
         # modified = row['ZMODIFICATIONDATE']
 
-        if has_table_of_contents(md_text):
+        if has_table_of_contents(md_text) and params['write']:
             print('[WARNING]: \'{}\' already has a Table of Contents, Ignoring...'.format(title))
             continue
 
@@ -245,7 +245,7 @@ def create_table_of_contents_github():
             with open(filepath, 'r') as file:
                 md_text = file.read()
 
-                if has_table_of_contents(md_text):
+                if has_table_of_contents(md_text) and params['write']:
                     print('[WARNING]: {} already has a Table of Contents, Ignoring...'.format(filepath))
                     continue
 


### PR DESCRIPTION
When `--no-write` is used, there's no reason to skip generating and printing a TOC if one already exists.

Related to #7 and #13. Does not resolve them because these are concerned with "write" mode.

This is just a quick fix for `--no-write`

Thanks for this package BTW, it's great :slightly_smiling_face: 